### PR TITLE
Refactor CCXTExchange and WOOExchange constructors to use 'params' in…

### DIFF
--- a/src/superalgorithm/exchange/ccxt_exchange.py
+++ b/src/superalgorithm/exchange/ccxt_exchange.py
@@ -16,11 +16,12 @@ from superalgorithm.types.data_types import (
     Trade,
     TradeType,
 )
+from superalgorithm.utils.config import config
 
 
 class CCXTExchange(BaseExchange):
 
-    def __init__(self, exchange_id: str, config: Any = {}):
+    def __init__(self, exchange_id: str, params: Any = {}):
 
         super().__init__()
 
@@ -28,7 +29,7 @@ class CCXTExchange(BaseExchange):
         self.ORDER_LOOKBACK_SECONDS = config.get("ORDER_LOOKBACK_SECONDS", 600)
         self.POLL_INTERVAL_SECONDS = config.get("POLL_INTERVAL_SECONDS", 10)
 
-        self.ccxt_client: Exchange = getattr(ccxt, exchange_id)(config)
+        self.ccxt_client: Exchange = getattr(ccxt, exchange_id)(params)
 
         self.trade_queue = asyncio.Queue()
         self.order_queue = asyncio.Queue()

--- a/src/superalgorithm/exchange/woo_exchange.py
+++ b/src/superalgorithm/exchange/woo_exchange.py
@@ -4,10 +4,10 @@ from superalgorithm.types.data_types import Order
 
 
 class WOOExchange(CCXTExchange):
-    def __init__(self, config: Any = {}):
-        super().__init__("woo", config)
+    def __init__(self, params: Any = {}):
+        super().__init__("woo", params)
 
-        self.hedge_mode = config.get("hedge_mode", False)
+        self.hedge_mode = params.get("hedge_mode", False)
 
     def _create_order_params(self, order: Order) -> dict:
         params = {

--- a/tests/exchange/woo_exchange_test.py
+++ b/tests/exchange/woo_exchange_test.py
@@ -24,7 +24,7 @@ symbol = "PNUT/USDT:USDT"
 
 @pytest.fixture(scope="module")
 async def setup_exchange():
-    exchange = WOOExchange(config=ccxt_config)
+    exchange = WOOExchange(params=ccxt_config)
 
     await exchange.start()
 


### PR DESCRIPTION
…stead of 'config'; update tests accordingly.